### PR TITLE
feat: adds support for `Trans` component

### DIFF
--- a/packages/codemod/test/transform.test.ts
+++ b/packages/codemod/test/transform.test.ts
@@ -3,7 +3,7 @@ import { applyTransform } from 'jscodeshift/src/testUtils.js'
 
 import { transform } from '@i18next-selector/codemod'
 
-const module = { default: transform, parser: 'ts' as const }
+const module = { default: transform, parser: 'tsx' as const }
 const options = { keySeparator: '.', nsSeparator: ':' }
 
 vi.describe('〖⛳️〗‹‹‹ ❲@i18next-selector/codemod❳', () => {
@@ -1078,6 +1078,63 @@ vi.describe('〖⛳️〗‹‹‹ ❲@i18next-selector/codemod❳', () => {
         t($ => condition ? $.abc.def.ghi : $.jkl.mno.pqr)"
       `)
     })
+  })
+
+  vi.describe('〖⛳️〗‹‹‹ ❲Trans❳', () => {
+    vi.test('〖⛳️〗› ❲transform❳: it transforms i18nextKey to selector', () => {
+
+      vi.expect.soft(
+        applyTransform(module, options, {
+          path: '',
+          source: [
+            `import { Trans } from "react-i18next"`,
+            ``,
+            `const a = <Trans i18nKey="my.key" />`,
+          ].join('\r')
+        })
+      ).toMatchInlineSnapshot
+        (`
+        "import { Trans } from "react-i18next"
+
+        const a = <Trans i18nKey={$ => $.my.key} />"
+      `)
+    })
+
+  })
+
+  vi.test('〖⛳️〗› ❲transform❳: it handles namespaces in the `Trans` component', () => {
+
+    vi.expect.soft(
+      applyTransform(module, options, {
+        path: '',
+        source: [
+          `import { Trans } from "react-i18next"`,
+          ``,
+          `const a = <Trans i18nKey="my.key" ns="ns1" />`,
+        ].join('\r')
+      })
+    ).toMatchInlineSnapshot
+      (`
+      "import { Trans } from "react-i18next"
+
+      const a = <Trans i18nKey={$ => $.my.key} ns="ns1" />"
+    `)
+
+    vi.expect.soft(
+      applyTransform(module, options, {
+        path: '',
+        source: [
+          `import { Trans } from "react-i18next"`,
+          ``,
+          `const a = <Trans i18nKey="ns1:my.key" />`,
+        ].join('\r')
+      })
+    ).toMatchInlineSnapshot
+      (`
+      "import { Trans } from "react-i18next"
+
+      const a = <Trans i18nKey={$ => $.my.key} ns="ns1" />"
+    `)
   })
 
 })


### PR DESCRIPTION
Will close #71 when this feature is finished (currently it only supports the [simplest cases](https://github.com/ahrjarrett/i18next-selector/compare/Trans-component?expand=1#diff-6e0b1390486cee5e8561b3ab116dfaf9e3660d10758a9ab7e17aa0284921b202R1086-R1138)