### PR TITLE
feat(codemod): adds support for template literals in `Trans` component's `i18nKey`

### DIFF
--- a/.changeset/fast-pianos-tap.md
+++ b/.changeset/fast-pianos-tap.md
@@ -1,0 +1,5 @@
+---
+"i18next-selector-codemod": patch
+---
+
+feat(codemod): adds support for template literals in `Trans` component's `i18nKey` prop

--- a/packages/codemod/test/transform.test.ts
+++ b/packages/codemod/test/transform.test.ts
@@ -1280,6 +1280,26 @@ vi.describe('〖⛳️〗‹‹‹ ❲@i18next-selector/codemod❳', () => {
         </>"
       `)
 
+      vi.expect.soft(
+        applyTransform(module, options, {
+          path: '',
+          source: [
+            `import { Trans } from "react-i18next"`,
+            ``,
+            `<>`,
+            `  <Trans i18nKey={\`my.key\`} />`,
+            // `  <Trans i18nKey={\`my\${key}\`} />`,
+            `</>`,
+          ].join('\r')
+        })
+      ).toMatchInlineSnapshot
+        (`
+        "import { Trans } from "react-i18next"
+
+        <>
+          <Trans i18nKey={$ => $.my.key} />
+        </>"
+      `)
     })
 
   })


### PR DESCRIPTION
Closes #101