### PR TITLE
feat(vite-plugin): add Yaml support

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -45,11 +45,13 @@
   },
   "devDependencies": {
     "@prettier/sync": "^0.6.1",
+    "@types/js-yaml": "^4.0.9",
     "vite": "^6.3.5"
   },
   "dependencies": {
     "@traversable/json": "^0.0.26",
-    "@traversable/registry": "^0.0.25"
+    "@traversable/registry": "^0.0.25",
+    "js-yaml": "^4.1.0"
   },
   "peerDependencies": {
     "vite": "6 - 7"

--- a/packages/vite-plugin/src/exports.ts
+++ b/packages/vite-plugin/src/exports.ts
@@ -2,6 +2,7 @@ export {
   i18nextVitePlugin,
   tsFileToDeclarationFile,
   jsonFileToDeclarationFile,
+  yamlFileToDeclarationFile
 } from './plugin.js'
 export {
   groupPluralKeys,

--- a/packages/vite-plugin/src/utils.ts
+++ b/packages/vite-plugin/src/utils.ts
@@ -79,6 +79,7 @@ export function rmPluralization(entry: [string, unknown], options: transform.Opt
 }
 
 export const isJsonFile = (x: string) => x.endsWith('.json')
+export const isYamlFile = (x: string) => x.endsWith('.yml') || x.endsWith('.yaml')
 export const isTsDeclarationFile = (x: string) => x.endsWith('.d.ts')
 export const isTsFile = (x: string) => x.endsWith('.ts') && !isTsDeclarationFile(x)
 

--- a/packages/vite-plugin/test/plugin.test.ts
+++ b/packages/vite-plugin/test/plugin.test.ts
@@ -4,6 +4,7 @@ import prettier from '@prettier/sync'
 import {
   tsFileToDeclarationFile,
   jsonFileToDeclarationFile,
+  yamlFileToDeclarationFile,
 } from '@i18next-selector/vite-plugin'
 
 const format = (src: string) => prettier.format(src, { parser: 'typescript', semi: false })
@@ -39,6 +40,19 @@ vi.describe('〖⛳️〗‹‹‹ ❲@i18next-selector/vite-plugin❳', () => {
         mixed: 'Quote "test" with\\nnewline and \\\\backslash'
         simple: "Normal text"
       }
+      "
+    `)
+  })
+
+  vi.it('〖⛳️〗› ❲yamlFileToDeclarationFile❳: generates valid d.ts from yaml (though conversion to json)', () => {
+    vi.expect(format(
+      yamlFileToDeclarationFile({
+        sourceFile: path.join(DIR_PATH, 'yaml_input.yaml'),
+        targetFile: path.join(DIR_PATH, '__generated__', 'yaml_input.d.ts')
+      }, defaultOptions)
+    )).toMatchInlineSnapshot
+      (`
+      "export declare const resources: { ok: "Ok"; main: { hello: "Hello world" } }
       "
     `)
   })

--- a/packages/vite-plugin/test/yaml_input.yaml
+++ b/packages/vite-plugin/test/yaml_input.yaml
@@ -1,0 +1,3 @@
+ok: Ok
+main:
+  hello: Hello world

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,10 +179,16 @@ importers:
       '@traversable/registry':
         specifier: ^0.0.25
         version: 0.0.25
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       '@prettier/sync':
         specifier: ^0.6.1
         version: 0.6.1(prettier@3.5.3)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.15.34)(yaml@2.8.0)
@@ -1040,6 +1046,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/jscodeshift@17.3.0':
     resolution: {integrity: sha512-ogvGG8VQQqAQQ096uRh+d6tBHrYuZjsumHirKtvBa5qEyTMN3IQJ7apo+sw9lxaB/iKWIhbbLlF3zmAWk9XQIg==}
 
@@ -1183,6 +1192,9 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   arktype@2.1.20:
     resolution: {integrity: sha512-IZCEEXaJ8g+Ijd59WtSYwtjnqXiwM8sWQ5EjGamcto7+HVN9eK0C4p0zDlCuAwWhpqr6fIBkxPuYDl4/Mcj/+Q==}
@@ -1781,6 +1793,10 @@ packages:
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
   jscodeshift@17.3.0:
@@ -3476,6 +3492,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/jscodeshift@17.3.0':
     dependencies:
       ast-types: 0.16.1
@@ -3683,6 +3701,8 @@ snapshots:
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+
+  argparse@2.0.1: {}
 
   arktype@2.1.20:
     dependencies:
@@ -4281,6 +4301,10 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
 
   jscodeshift@17.3.0:
     dependencies:


### PR DESCRIPTION
**Description**

Closes #128.

1. I've tried to keep it to the existing codestyle and don't refactor stuff
2. `js-yaml` is added to parse YAML to align with https://github.com/alienfast/vite-plugin-i18next-loader (which is likely to be used together with this plugin)

**Checklist** —

- [x] My PR's title follows the [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references any related issues
  - [x] Any new feature or breaking change must come with an associated Issue or Discussion
  - [x] Any added dependency must include an associated Issue or Discussion
- [x] My PR adds relevant tests that they would have failed without my PR (when applicable)

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: ✨ New feature